### PR TITLE
ci: harden CNCF calendar generation pipeline

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,12 +8,19 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: cncf-calendar-update
+  cancel-in-progress: true
+
 jobs:
   build-and-propose-update:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Generate Project Page
         id: build-step
@@ -22,7 +29,7 @@ jobs:
           lfx-token: ${{ secrets.LFX_TOKEN }}
 
       - name: Create Pull Request with updated index.html
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: "Automated CNCF Calendar Update"

--- a/calendar_update/action.yaml
+++ b/calendar_update/action.yaml
@@ -16,29 +16,59 @@ runs:
   steps:
     - id: run-script
       name: Run the entrypoint script
-      run: ${{ github.action_path }}/entrypoint.sh # This line works automatically
+      # Invoke with bash explicitly so we don't depend on the file's execute
+      # bit (which can be lost on checkout/clone) and don't break on paths
+      # with spaces.
+      run: bash "${{ github.action_path }}/entrypoint.sh"
       shell: bash
+      working-directory: ${{ github.workspace }}
       env:
         LFX_TOKEN: ${{ inputs.lfx-token }}
+
+    - name: Validate generated output
+      shell: bash
+      run: |
+        set -euo pipefail
+        HTML_FILE="${{ steps.run-script.outputs.html_file }}"
+        if [ -z "${HTML_FILE}" ]; then
+          echo "::error::entrypoint.sh did not report 'html_file' in GITHUB_OUTPUT."
+          exit 1
+        fi
+        if [ ! -f "${HTML_FILE}" ]; then
+          echo "::error::Reported file (${HTML_FILE}) does not exist on disk."
+          exit 1
+        fi
+        echo "Verified generated file: ${HTML_FILE}"
+
     - name: Configure git user for signed commit
       shell: bash
+      # DCO note: the commit is signed off as GITHUB_ACTOR, i.e. whoever
+      # triggered the workflow. This is only meaningful while the action runs
+      # on a manual trigger (workflow_dispatch). If it is ever reused with an
+      # automatic trigger, GITHUB_ACTOR becomes a bot and the sign-off no
+      # longer represents a responsible human — revisit this assumption first.
       run: |
         set -euo pipefail
-        GIT_USER_NAME="${GITHUB_ACTOR}"
-        GIT_USER_EMAIL="${GITHUB_ACTOR}@users.noreply.github.com"
-        git config user.name "${GIT_USER_NAME}"
-        git config user.email "${GIT_USER_EMAIL}"
+        git config user.name "${GITHUB_ACTOR}"
+        git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
     - name: Stage and commit changes with DCO sign-off
       shell: bash
+      working-directory: ${{ github.workspace }}
       run: |
         set -euo pipefail
-        # Stage changes (only add the generated HTML to be safe)
-        if [ -n "${GITHUB_WORKSPACE:-}" ] && [ -f "${GITHUB_WORKSPACE}/index.html" ]; then
-          git add "${GITHUB_WORKSPACE}/index.html"
-        else
-          git add -A
+        HTML_FILE="${{ steps.run-script.outputs.html_file }}"
+
+        # Only add the explicitly generated file. If it is missing, fail
+        # instead of falling back to `git add -A`, so we never sweep unwanted
+        # changes (logs, temp files, etc.) into the automated PR.
+        if [ ! -f "${HTML_FILE}" ]; then
+          echo "::error::Expected ${HTML_FILE} was not found to commit."
+          exit 1
         fi
-        # Commit only if there are staged changes
+        git add "${HTML_FILE}"
+
+        # Commit only if there are staged changes.
         if git diff --cached --quiet; then
           echo "No changes to commit."
           exit 0

--- a/calendar_update/entrypoint.sh
+++ b/calendar_update/entrypoint.sh
@@ -190,8 +190,9 @@ fetch_all_projects() {
             fi
             retry_count=$((retry_count + 1))
             echo "Warning: LFX API request failed (offset=$offset), retry $retry_count/$CURL_MAX_RETRIES..." >&2
-            sleep $((retry_count * 2))
-        done
+            if [ "$retry_count" -lt "$CURL_MAX_RETRIES" ]; then
+                sleep $((retry_count * 2))
+            fi
 
         if [ "$retry_count" -eq "$CURL_MAX_RETRIES" ]; then
             echo "Error: LFX API request failed after $CURL_MAX_RETRIES retries (offset=$offset). Aborting." >&2

--- a/calendar_update/entrypoint.sh
+++ b/calendar_update/entrypoint.sh
@@ -1,34 +1,43 @@
 #!/bin/bash
 # entrypoint.sh
 #
-# This script fetches CNCF project data from the LFX API, processes it, and generates an HTML file listing projects by category.
-# It is designed for use in a GitHub Action and expects the LFX_TOKEN environment variable to be set.
+# Fetches CNCF project data from the LFX API, processes it, and generates an
+# HTML file listing projects by category. Expects LFX_TOKEN and GITHUB_WORKSPACE
+# to be set (designed to run inside a GitHub Action).
 
-# Strict error handling: exit on error, unset variable, or failed pipeline
 set -euo pipefail
 
-# Trap to ensure temp files are cleaned up on exit or error
+# Initialize empty BEFORE registering the trap, so cleanup() never runs on an
+# unset variable if the script exits before the temp file is created.
+FORMING_PROJECTS_TEMP_FILE=""
 cleanup() {
-    rm -f "$FORMING_PROJECTS_TEMP_FILE"
+    [ -n "${FORMING_PROJECTS_TEMP_FILE:-}" ] && rm -f "$FORMING_PROJECTS_TEMP_FILE"
 }
 trap cleanup EXIT
 
-# 1. TOKEN VALIDATION: Read the token from an environment variable.
 if [ -z "${LFX_TOKEN:-}" ]; then
     echo "Error: The LFX_TOKEN environment variable is not set." >&2
     exit 1
 fi
 
-# API and HTML settings
+if [ -z "${GITHUB_WORKSPACE:-}" ]; then
+    echo "Error: GITHUB_WORKSPACE is not set (this script expects to run inside GitHub Actions)." >&2
+    exit 1
+fi
+
 BASE_API_URL="https://api-gw.platform.linuxfoundation.org/project-service/v1/projects"
 OUTPUT_HTML_FILE="${GITHUB_WORKSPACE}/index.html"
 PAGE_SIZE=100
-OFFSET=0
 FOUNDATION_ID="a0941000002wBz4AAE" # CNCF Foundation ID
 FORMING_PROJECTS_STATUS="Formation - Exploratory"
+CURL_MAX_TIME=30
+CURL_MAX_RETRIES=3
+
 FORMING_PROJECTS_TEMP_FILE=$(mktemp)
 
-# JQ processors for HTML generation
+# JQ processors. @html escapes Name/ProjectLogo/RepositoryURL to prevent broken
+# attributes / HTML injection from externally sourced API data. RepositoryURL is
+# additionally validated with test("^https?://") before being used as an href.
 JQ_HTML_PROCESSOR='
 def category_rank:
   if .Category == "TAG" then 1
@@ -39,7 +48,7 @@ def category_rank:
   end;
 [inputs] |
 map(. + {category_sort_key: category_rank}) |
-map(select(select(.category_sort_key > 0))) |
+map(select(.category_sort_key > 0)) |
 sort_by([.category_sort_key, .Name]) |
 group_by(.Category) |
 sort_by(.[0].category_sort_key) |
@@ -49,8 +58,8 @@ map(
     (if $current_category_name == "TAG" then "<p>CNCF Technical Oversight Committee (TOC) meetings can be found on the <a href=\"https://zoom-lfx.platform.linuxfoundation.org/meetings/cncf?projects=cncf&view=week\">CNCF Main calendar (Project calendar)</a></p>" else "" end) +
     "<ul class=\"project-list\">\n" +
     (map(
-        "<li class=\"project-item\"><img src=\"" + ((.ProjectLogo | select(length > 0)) // "https://lf-master-project-logos-prod.s3.us-east-2.amazonaws.com/cncf.svg") + "\" alt=\"" + .Name + " Logo\" class=\"project-logo\"> " + .Name + " (<a href=\"https://zoom-lfx.platform.linuxfoundation.org/meetings/" + (.Slug | @uri) + "\">Project calendar</a>)" +
-        (if .RepositoryURL and (.RepositoryURL | length > 0) then " (<a href=\"" + .RepositoryURL + "\">Project code</a>)" else "" end) +
+        "<li class=\"project-item\"><img src=\"" + (((.ProjectLogo | select(length > 0)) // "https://lf-master-project-logos-prod.s3.us-east-2.amazonaws.com/cncf.svg") | @html) + "\" alt=\"" + (.Name | @html) + " Logo\" class=\"project-logo\"> " + (.Name | @html) + " (<a href=\"https://zoom-lfx.platform.linuxfoundation.org/meetings/" + (.Slug | @uri) + "\">Project calendar</a>)" +
+        (if .RepositoryURL and (.RepositoryURL | length > 0) and (.RepositoryURL | test("^https?://")) then " (<a href=\"" + (.RepositoryURL | @html) + "\">Project code</a>)" else "" end) +
         "</li>\n"
     ) | add) +
     "</ul>\n"
@@ -58,14 +67,13 @@ map(
 '
 
 JQ_FORMING_PROJECTS_PROCESSOR='
-. | # Expects an array as input
+. |
 sort_by(.Name) |
-# Now map the array to HTML, including the count (length of the array)
 (length) as $project_count |
 "<h2>Forming Projects (" + ($project_count | tostring) + ")</h2>\n<ul class=\"project-list\">\n" +
 (map(
-    "<li class=\"project-item\"><img src=\"" + ((.ProjectLogo | select(length > 0)) // "https://lf-master-project-logos-prod.s3.us-east-2.amazonaws.com/cncf.svg") + "\" alt=\"" + .Name + " Logo\" class=\"project-logo\"> " + .Name +
-    (if .RepositoryURL and (.RepositoryURL | length > 0) then " (<a href=\"" + .RepositoryURL + "\">GitHub</a>)" else "" end) +
+    "<li class=\"project-item\"><img src=\"" + (((.ProjectLogo | select(length > 0)) // "https://lf-master-project-logos-prod.s3.us-east-2.amazonaws.com/cncf.svg") | @html) + "\" alt=\"" + (.Name | @html) + " Logo\" class=\"project-logo\"> " + (.Name | @html) +
+    (if .RepositoryURL and (.RepositoryURL | length > 0) and (.RepositoryURL | test("^https?://")) then " (<a href=\"" + (.RepositoryURL | @html) + "\">GitHub</a>)" else "" end) +
     "</li>\n"
 ) | add) +
 "</ul>\n"
@@ -163,18 +171,36 @@ print_html_footer() {
 EOF
 }
 
-# Function: Fetch all paginated project data from the API
+# Fetch all paginated project data from the API.
+# --fail makes an HTTP 4xx/5xx count as a curl failure; failed requests are
+# retried with backoff; and if they still fail, the script exits (1) instead of
+# silently breaking out of the loop and publishing an incomplete page.
 fetch_all_projects() {
     local offset=0
     while true; do
         local current_api_url="${BASE_API_URL}?offset=${offset}&limit=${PAGE_SIZE}"
-        local response
-        response=$(curl -sS -H "Authorization: Bearer $LFX_TOKEN" "$current_api_url")
+        local response=""
+        local retry_count=0
 
-        # Validate JSON and presence of .Data
+        while [ "$retry_count" -lt "$CURL_MAX_RETRIES" ]; do
+            if response=$(curl -sS --fail --max-time "$CURL_MAX_TIME" \
+                -H "Authorization: Bearer $LFX_TOKEN" \
+                "$current_api_url"); then
+                break
+            fi
+            retry_count=$((retry_count + 1))
+            echo "Warning: LFX API request failed (offset=$offset), retry $retry_count/$CURL_MAX_RETRIES..." >&2
+            sleep $((retry_count * 2))
+        done
+
+        if [ "$retry_count" -eq "$CURL_MAX_RETRIES" ]; then
+            echo "Error: LFX API request failed after $CURL_MAX_RETRIES retries (offset=$offset). Aborting." >&2
+            exit 1
+        fi
+
         if ! echo "$response" | jq -e '.Data' > /dev/null 2>&1; then
-            echo "Error: Invalid JSON response or 'Data' array not found for offset $offset." >&2
-            break
+            echo "Error: Invalid JSON response or 'Data' array missing for offset $offset. Aborting." >&2
+            exit 1
         fi
 
         local projects_received_on_page
@@ -183,12 +209,15 @@ fetch_all_projects() {
             break
         fi
 
-        # Output main category projects as JSON lines
-        echo "$response" | jq -c '.Data[] | select(.Foundation.ID == "'"$FOUNDATION_ID"'" and .Status == "Active") | {Name: .Name, Slug: .Slug, Category: .Category, ProjectLogo: .ProjectLogo, RepositoryURL: .RepositoryURL}'
+        # Output main category projects as JSON lines.
+        # --arg avoids interpolating shell variables directly into the jq program.
+        echo "$response" | jq -c --arg fid "$FOUNDATION_ID" \
+            '.Data[] | select(.Foundation.ID == $fid and .Status == "Active") | {Name: .Name, Slug: .Slug, Category: .Category, ProjectLogo: .ProjectLogo, RepositoryURL: .RepositoryURL}'
 
         # Output forming projects to temp file
         local forming_json
-        forming_json=$(echo "$response" | jq -c '.Data[] | select(.Foundation.ID == "'"$FOUNDATION_ID"'" and .Status == "'"$FORMING_PROJECTS_STATUS"'") | {Name: .Name, ProjectLogo: .ProjectLogo, RepositoryURL: .RepositoryURL}')
+        forming_json=$(echo "$response" | jq -c --arg fid "$FOUNDATION_ID" --arg status "$FORMING_PROJECTS_STATUS" \
+            '.Data[] | select(.Foundation.ID == $fid and .Status == $status) | {Name: .Name, ProjectLogo: .ProjectLogo, RepositoryURL: .RepositoryURL}')
         if [ -n "$forming_json" ]; then
             echo "$forming_json" >> "$FORMING_PROJECTS_TEMP_FILE"
         fi
@@ -206,9 +235,10 @@ generate_main_categories_html() {
 # Function: Generate HTML for forming projects using jq
 generate_forming_projects_html() {
     if [ -s "$FORMING_PROJECTS_TEMP_FILE" ]; then
-        cat "$FORMING_PROJECTS_TEMP_FILE" | jq -s '.' | jq -r "$JQ_FORMING_PROJECTS_PROCESSOR"
+        jq -s '.' "$FORMING_PROJECTS_TEMP_FILE" | jq -r "$JQ_FORMING_PROJECTS_PROCESSOR"
     else
-        echo "<h2>Forming Projects (0)</h2>\n<ul class=\"project-list\">\n</ul>"
+        # Use printf, not echo: echo without -e printed "\n" as a literal string.
+        printf '<h2>Forming Projects (0)</h2>\n<ul class="project-list">\n</ul>\n'
     fi
 }
 
@@ -223,8 +253,22 @@ generate_forming_projects_html() {
 } > "$OUTPUT_HTML_FILE"
 
 # Log summary and set GitHub Action output
-TOTAL_FORMING_PROJECTS_FINAL_COUNT=$(if [ -s "$FORMING_PROJECTS_TEMP_FILE" ]; then cat "$FORMING_PROJECTS_TEMP_FILE" | wc -l; else echo 0; fi)
-echo "Total projects matching Foundation ID filter (main categories): (count from HTML if accurate, or 0 if from subshell)"
+TOTAL_FORMING_PROJECTS_FINAL_COUNT=0
+if [ -s "$FORMING_PROJECTS_TEMP_FILE" ]; then
+    TOTAL_FORMING_PROJECTS_FINAL_COUNT=$(wc -l < "$FORMING_PROJECTS_TEMP_FILE")
+fi
+
+TOTAL_PROJECT_ITEMS=$(grep -o 'class="project-item"' "$OUTPUT_HTML_FILE" | wc -l || true)
+
+# Sanity check: if no project at all was found (main or forming), something went
+# wrong upstream (token, API schema, filter). Fail instead of silently
+# publishing an empty page.
+if [ "$TOTAL_PROJECT_ITEMS" -eq 0 ]; then
+    echo "Error: No projects found in the API response. Aborting to avoid publishing an empty page." >&2
+    exit 1
+fi
+
+echo "Total project items in the generated page (all categories): $TOTAL_PROJECT_ITEMS"
 echo "Total 'Formation - Exploratory' projects identified: $TOTAL_FORMING_PROJECTS_FINAL_COUNT"
 echo "HTML file generated: $OUTPUT_HTML_FILE"
 echo "html_file=${OUTPUT_HTML_FILE}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Combines #43, #44 and #45 into one PR, as requested.

**Workflow (`main.yaml`)**
- Pin `actions/checkout` and `peter-evans/create-pull-request` to commit SHAs
- `persist-credentials: false` on checkout
- Add a job `timeout-minutes` and a `concurrency` group

**Composite action (`action.yaml`)**
- Run `entrypoint.sh` via `bash` (don't rely on the execute bit)
- Drop the `git add -A` fallback so only the generated `index.html` is committed

**Script (`entrypoint.sh`)**
- `curl --fail` with retries, so an API/token error fails the run instead of publishing an empty page
- HTML-escape the API-sourced fields and only link `RepositoryURL` when it starts with `http(s)://`
- Fix the literal `\n` in the empty "Forming Projects" case

On the labels question: `automated` doesn't exist in this repo (only `documentation` does), so I left `labels: automated, documentation` commented out to avoid failing the create-PR step. Happy to add just `documentation`, or create the `automated` label — whichever you prefer.
